### PR TITLE
feat: Rebrand to SOLA and implement full page translations

### DIFF
--- a/about.html
+++ b/about.html
@@ -3,7 +3,7 @@
 <head>
   <meta charset="UTF-8">
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
-  <title>About Us - Millenium Drones</title>
+  <title>About Us - SOLA</title>
   <script src="https://cdn.tailwindcss.com"></script>
   <script>
     tailwind.config = {
@@ -48,7 +48,7 @@
               <path stroke-linecap="round" stroke-linejoin="round" d="M12.75 3.03v.568c0 .334.148.65.405.85l.708.707a2.25 2.25 0 010 3.182L11.53 10.53a2.25 2.25 0 01-3.182 0L6.272 8.455a2.25 2.25 0 010-3.182L7.025 4.48c.205-.2.518-.303.85-.303h.568a2.25 2.25 0 002.25-2.25v-.568c0-.334.148-.65.405-.85L12 2.25l.708.707a1.125 1.125 0 00.85.405h.568c1.24 0 2.25 1.01 2.25 2.25v.568c0 .334-.148.65-.405.85l-.708.707a2.25 2.25 0 000 3.182l2.473 2.472a2.25 2.25 0 003.182 0l.707-.707c.257-.257.405-.596.405-.955V8.25a2.25 2.25 0 00-2.25-2.25h-.568a1.125 1.125 0 00-.85.405L15.75 6.75v-.568a2.25 2.25 0 00-2.25-2.25h-.568A1.125 1.125 0 0012.75 3.03z" />
               <path stroke-linecap="round" stroke-linejoin="round" d="M6 18H4.5a2.25 2.25 0 01-2.25-2.25V13.5A2.25 2.25 0 014.5 11.25H6M18 18h1.5a2.25 2.25 0 002.25-2.25V13.5A2.25 2.25 0 0019.5 11.25H18M12 12.75V21m0 0H9.75M12 21h2.25" />
             </svg>
-            <span class="font-bold text-2xl tracking-tight" data-translate-key="heroTitle1">Millenium Drones</span>
+            <span class="font-bold text-2xl tracking-tight" data-translate-key="heroTitle1">SOLA</span>
           </a>
         </div>
         <div class="hidden md:block">
@@ -103,30 +103,30 @@
     <div class="bg-brand-primary py-16 sm:py-24">
       <div class="max-w-7xl mx-auto px-4 sm:px-6 lg:px-8">
         <div class="text-center">
-          <h1 class="text-4xl font-extrabold text-white sm:text-5xl sm:tracking-tight lg:text-6xl">
-            About Millenium Drones
+          <h1 class="text-4xl font-extrabold text-white sm:text-5xl sm:tracking-tight lg:text-6xl" data-translate-key="aboutPageTitle">
+            About SOLA
           </h1>
-          <p class="mt-6 max-w-3xl mx-auto text-xl text-brand-text">
+          <p class="mt-6 max-w-3xl mx-auto text-xl text-brand-text" data-translate-key="aboutPageSlogan">
             Pioneering the future of aerial solutions with passion and precision.
           </p>
         </div>
 
         <div class="mt-16 bg-brand-secondary shadow-xl rounded-lg p-8 md:p-12">
-          <h2 class="text-2xl font-bold text-brand-accent mb-4">Our Story</h2>
-          <p class="text-brand-text leading-relaxed mb-6">
-            Founded in 2020 by a team of passionate engineers and aviation experts, Millenium Drones was born from a shared vision: to make advanced aerial technology accessible and impactful. We saw the potential for drones to transform various sectors, from agriculture and construction to public safety and cinematography. Starting in a small workshop, we meticulously designed and tested our first prototypes, focusing on durability, performance, and user-friendliness. Today, Millenium Drones has grown into a trusted name, known for pushing the boundaries of what's possible with unmanned aerial systems. Our commitment to research and development ensures that we stay at the forefront of the industry, delivering cutting-edge solutions to our clients worldwide.
+          <h2 class="text-2xl font-bold text-brand-accent mb-4" data-translate-key="ourStoryTitle">Our Story</h2>
+          <p class="text-brand-text leading-relaxed mb-6" data-translate-key="ourStoryParagraph1">
+            Founded in 2020 by a team of passionate engineers and aviation experts, SOLA was born from a shared vision: to make advanced aerial technology accessible and impactful. We saw the potential for drones to transform various sectors, from agriculture and construction to public safety and cinematography. Starting in a small workshop, we meticulously designed and tested our first prototypes, focusing on durability, performance, and user-friendliness. Today, SOLA has grown into a trusted name, known for pushing the boundaries of what's possible with unmanned aerial systems. Our commitment to research and development ensures that we stay at the forefront of the industry, delivering cutting-edge solutions to our clients worldwide.
           </p>
 
           <div class="grid md:grid-cols-2 gap-8 mb-8">
             <div>
-              <h2 class="text-2xl font-bold text-brand-accent mb-4">Our Mission</h2>
-              <p class="text-brand-text leading-relaxed">
+              <h2 class="text-2xl font-bold text-brand-accent mb-4" data-translate-key="ourMissionTitle">Our Mission</h2>
+              <p class="text-brand-text leading-relaxed" data-translate-key="ourMissionParagraph">
                 Our mission is to revolutionize industries through innovative aerial technology, providing reliable, efficient, and intelligent drone solutions that empower our customers to achieve more.
               </p>
             </div>
             <div>
-              <h2 class="text-2xl font-bold text-brand-accent mb-4">Our Vision</h2>
-              <p class="text-brand-text leading-relaxed">
+              <h2 class="text-2xl font-bold text-brand-accent mb-4" data-translate-key="ourVisionTitle">Our Vision</h2>
+              <p class="text-brand-text leading-relaxed" data-translate-key="ourVisionParagraph">
                 To be the global leader in drone technology, recognized for our commitment to quality, innovation, and customer success.
               </p>
             </div>
@@ -134,19 +134,19 @@
         </div>
 
         <div class="mt-16">
-          <h2 class="text-3xl font-extrabold text-white text-center mb-12">Our Core Values</h2>
+          <h2 class="text-3xl font-extrabold text-white text-center mb-12" data-translate-key="coreValuesTitle">Our Core Values</h2>
           <div class="grid grid-cols-1 md:grid-cols-3 gap-8">
             <div class="bg-brand-secondary p-6 rounded-lg shadow-lg text-center">
               <svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke-width="1.5" stroke="currentColor" class="w-16 h-16 text-brand-accent mx-auto mb-4"><path stroke-linecap="round" stroke-linejoin="round" d="M8.25 4.5l7.5 7.5-7.5 7.5" /><path stroke-linecap="round" stroke-linejoin="round" d="M3.75 4.5l7.5 7.5-7.5 7.5" /></svg>
-              <h3 class="text-xl font-semibold text-white mb-2">Innovation</h3>
-              <p class="text-brand-text text-sm">
+              <h3 class="text-xl font-semibold text-white mb-2" data-translate-key="valueInnovationTitle">Innovation</h3>
+              <p class="text-brand-text text-sm" data-translate-key="valueInnovationDesc">
                 Constantly pushing the boundaries of technology to deliver cutting-edge solutions.
               </p>
             </div>
             <div class="bg-brand-secondary p-6 rounded-lg shadow-lg text-center">
               <svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke-width="1.5" stroke="currentColor" class="w-16 h-16 text-brand-accent mx-auto mb-4"><path stroke-linecap="round" stroke-linejoin="round" d="M9 12.75L11.25 15 15 9.75m-3-7.036A11.959 11.959 0 013.598 6 11.99 11.99 0 003 9.749c0 5.592 3.824 10.29 9 11.623 5.176-1.332 9-6.03 9-11.622 0-1.31-.21-2.571-.598-3.751h-.152c-3.196 0-6.1-1.248-8.25-3.285z" /></svg>
-              <h3 class="text-xl font-semibold text-white mb-2">Reliability</h3>
-              <p class="text-brand-text text-sm">
+              <h3 class="text-xl font-semibold text-white mb-2" data-translate-key="valueReliabilityTitle">Reliability</h3>
+              <p class="text-brand-text text-sm" data-translate-key="valueReliabilityDesc">
                 Building robust and dependable drones that perform consistently in demanding environments.
               </p>
             </div>
@@ -155,8 +155,8 @@
                 <path stroke-linecap="round" stroke-linejoin="round" d="M12.75 3.03v.568c0 .334.148.65.405.85l.708.707a2.25 2.25 0 010 3.182L11.53 10.53a2.25 2.25 0 01-3.182 0L6.272 8.455a2.25 2.25 0 010-3.182L7.025 4.48c.205-.2.518-.303.85-.303h.568a2.25 2.25 0 002.25-2.25v-.568c0-.334.148-.65.405-.85L12 2.25l.708.707a1.125 1.125 0 00.85.405h.568c1.24 0 2.25 1.01 2.25 2.25v.568c0 .334-.148.65-.405.85l-.708.707a2.25 2.25 0 000 3.182l2.473 2.472a2.25 2.25 0 003.182 0l.707-.707c.257-.257.405-.596.405-.955V8.25a2.25 2.25 0 00-2.25-2.25h-.568a1.125 1.125 0 00-.85.405L15.75 6.75v-.568a2.25 2.25 0 00-2.25-2.25h-.568A1.125 1.125 0 0012.75 3.03z" />
                 <path stroke-linecap="round" stroke-linejoin="round" d="M6 18H4.5a2.25 2.25 0 01-2.25-2.25V13.5A2.25 2.25 0 014.5 11.25H6M18 18h1.5a2.25 2.25 0 002.25-2.25V13.5A2.25 2.25 0 0019.5 11.25H18M12 12.75V21m0 0H9.75M12 21h2.25" />
               </svg>
-              <h3 class="text-xl font-semibold text-white mb-2">Customer Focus</h3>
-              <p class="text-brand-text text-sm">
+              <h3 class="text-xl font-semibold text-white mb-2" data-translate-key="valueCustomerFocusTitle">Customer Focus</h3>
+              <p class="text-brand-text text-sm" data-translate-key="valueCustomerFocusDesc">
                 Understanding and exceeding our customers' needs with tailored solutions and support.
               </p>
             </div>
@@ -166,10 +166,10 @@
         <div class="mt-16 text-center">
           <img 
             src="https://picsum.photos/seed/teamPhoto/1200/600" 
-            alt="Millenium Drones Team" 
+            alt="SOLA Team"
             class="rounded-lg shadow-xl mx-auto"
           />
-          <p class="mt-4 text-brand-text italic">The dedicated team behind Millenium Drones.</p>
+          <p class="mt-4 text-brand-text italic" data-translate-key="teamImageCaption">The dedicated team behind SOLA.</p>
         </div>
       </div>
     </div>
@@ -177,7 +177,7 @@
 
   <footer class="bg-brand-secondary text-brand-text py-8">
     <div class="max-w-7xl mx-auto px-4 sm:px-6 lg:px-8 text-center">
-      <p><span data-translate-key="footerRights">&copy; <span id="current-year"></span> Millenium Drones. All rights reserved.</span></p>
+      <p><span data-translate-key="footerRights">&copy; <span id="current-year"></span> SOLA. All rights reserved.</span></p>
       <p class="text-sm mt-1" data-translate-key="footerSlogan">Pioneering the Future of Aerial Technology.</p>
     </div>
   </footer>

--- a/contact.html
+++ b/contact.html
@@ -3,7 +3,7 @@
 <head>
   <meta charset="UTF-8">
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
-  <title>Contact Us - Millenium Drones</title>
+  <title>Contact Us - SOLA</title>
   <script src="https://cdn.tailwindcss.com"></script>
   <script>
     tailwind.config = {
@@ -48,7 +48,7 @@
               <path stroke-linecap="round" stroke-linejoin="round" d="M12.75 3.03v.568c0 .334.148.65.405.85l.708.707a2.25 2.25 0 010 3.182L11.53 10.53a2.25 2.25 0 01-3.182 0L6.272 8.455a2.25 2.25 0 010-3.182L7.025 4.48c.205-.2.518-.303.85-.303h.568a2.25 2.25 0 002.25-2.25v-.568c0-.334.148-.65.405-.85L12 2.25l.708.707a1.125 1.125 0 00.85.405h.568c1.24 0 2.25 1.01 2.25 2.25v.568c0 .334-.148.65-.405.85l-.708.707a2.25 2.25 0 000 3.182l2.473 2.472a2.25 2.25 0 003.182 0l.707-.707c.257-.257.405-.596.405-.955V8.25a2.25 2.25 0 00-2.25-2.25h-.568a1.125 1.125 0 00-.85.405L15.75 6.75v-.568a2.25 2.25 0 00-2.25-2.25h-.568A1.125 1.125 0 0012.75 3.03z" />
               <path stroke-linecap="round" stroke-linejoin="round" d="M6 18H4.5a2.25 2.25 0 01-2.25-2.25V13.5A2.25 2.25 0 014.5 11.25H6M18 18h1.5a2.25 2.25 0 002.25-2.25V13.5A2.25 2.25 0 0019.5 11.25H18M12 12.75V21m0 0H9.75M12 21h2.25" />
             </svg>
-            <span class="font-bold text-2xl tracking-tight" data-translate-key="heroTitle1">Millenium Drones</span>
+            <span class="font-bold text-2xl tracking-tight" data-translate-key="heroTitle1">SOLA</span>
           </a>
         </div>
         <div class="hidden md:block">
@@ -103,10 +103,10 @@
     <div class="bg-brand-primary py-16 sm:py-24">
       <div class="max-w-7xl mx-auto px-4 sm:px-6 lg:px-8">
         <div class="text-center mb-16">
-          <h1 class="text-4xl font-extrabold text-white sm:text-5xl sm:tracking-tight lg:text-6xl">
+          <h1 class="text-4xl font-extrabold text-white sm:text-5xl sm:tracking-tight lg:text-6xl" data-translate-key="contactPageTitle">
             Get In Touch
           </h1>
-          <p class="mt-6 max-w-3xl mx-auto text-xl text-brand-text">
+          <p class="mt-6 max-w-3xl mx-auto text-xl text-brand-text" data-translate-key="contactPageSlogan">
             We're here to help with any questions you have about our drones or services. Reach out and let's talk.
           </p>
         </div>
@@ -114,10 +114,10 @@
         <div class="grid md:grid-cols-2 gap-12 items-start">
           <!-- Contact Form -->
           <div class="bg-brand-secondary p-8 rounded-lg shadow-xl">
-            <h2 class="text-2xl font-bold text-brand-accent mb-6">Send Us a Message</h2>
+            <h2 class="text-2xl font-bold text-brand-accent mb-6" data-translate-key="sendMessageTitle">Send Us a Message</h2>
             <form id="contact-form" class="space-y-6">
               <div>
-                <label for="name" class="block text-sm font-medium text-brand-text">Full Name</label>
+                <label for="name" class="block text-sm font-medium text-brand-text" data-translate-key="formLabelName">Full Name</label>
                 <input
                   type="text"
                   name="name"
@@ -127,7 +127,7 @@
                 />
               </div>
               <div>
-                <label for="email" class="block text-sm font-medium text-brand-text">Email Address</label>
+                <label for="email" class="block text-sm font-medium text-brand-text" data-translate-key="formLabelEmail">Email Address</label>
                 <input
                   type="email"
                   name="email"
@@ -137,7 +137,7 @@
                 />
               </div>
               <div>
-                <label for="subject" class="block text-sm font-medium text-brand-text">Subject</label>
+                <label for="subject" class="block text-sm font-medium text-brand-text" data-translate-key="formLabelSubject">Subject</label>
                 <input
                   type="text"
                   name="subject"
@@ -147,7 +147,7 @@
                 />
               </div>
               <div>
-                <label for="message" class="block text-sm font-medium text-brand-text">Message</label>
+                <label for="message" class="block text-sm font-medium text-brand-text" data-translate-key="formLabelMessage">Message</label>
                 <textarea
                   name="message"
                   id="message"
@@ -160,6 +160,7 @@
                 <button
                   type="submit"
                   class="w-full flex justify-center py-3 px-4 border border-transparent rounded-md shadow-sm text-sm font-medium text-brand-primary bg-brand-accent hover:bg-opacity-80 focus:outline-none focus:ring-2 focus:ring-offset-2 focus:ring-brand-accent transition-colors duration-150"
+                  data-translate-key="formButtonSend"
                 >
                   Send Message
                 </button>
@@ -172,29 +173,29 @@
 
           <!-- Contact Details -->
           <div class="bg-brand-secondary p-8 rounded-lg shadow-xl">
-            <h2 class="text-2xl font-bold text-brand-accent mb-6">Contact Information</h2>
+            <h2 class="text-2xl font-bold text-brand-accent mb-6" data-translate-key="contactInfoTitle">Contact Information</h2>
             <div class="space-y-4 text-brand-text">
               <div class="flex items-start">
                 <svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke-width="1.5" stroke="currentColor" class="flex-shrink-0 h-6 w-6 text-brand-accent mr-3 mt-1"><path stroke-linecap="round" stroke-linejoin="round" d="M21.75 6.75v10.5a2.25 2.25 0 01-2.25 2.25h-15a2.25 2.25 0 01-2.25-2.25V6.75m19.5 0A2.25 2.25 0 0019.5 4.5h-15a2.25 2.25 0 00-2.25 2.25m19.5 0v.243a2.25 2.25 0 01-1.07 1.916l-7.5 4.615a2.25 2.25 0 01-2.36 0L3.32 8.91a2.25 2.25 0 01-1.07-1.916V6.75" /></svg>
                 <div>
-                  <h3 class="text-lg font-semibold text-white">Email Us</h3>
-                  <a href="mailto:info@milleniumdrones.com" class="hover:text-brand-accent transition-colors">
-                    info@milleniumdrones.com
+                  <h3 class="text-lg font-semibold text-white" data-translate-key="contactEmailTitle">Email Us</h3>
+                  <a href="mailto:info@sola-drones.com" class="hover:text-brand-accent transition-colors" data-translate-key="contactEmailValue">
+                    info@sola-drones.com
                   </a>
                 </div>
               </div>
               <div class="flex items-start">
                  <svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke-width="1.5" stroke="currentColor" class="flex-shrink-0 h-6 w-6 text-brand-accent mr-3 mt-1"><path stroke-linecap="round" stroke-linejoin="round" d="M2.25 6.75c0 8.284 6.716 15 15 15h2.25a2.25 2.25 0 002.25-2.25v-1.372c0-.516-.051-.996-.15-1.462l-1.967-5.246a2.25 2.25 0 00-2.165-1.618H16.5c-.568 0-1.07.248-1.442.649l-1.014.903a12.32 12.32 0 01-5.21-5.21l.903-1.014c.401-.372.649-.874.649-1.442V4.5A2.25 2.25 0 0010.5 2.25H9c-8.284 0-15 6.716-15 15V11.25a2.25 2.25 0 012.25-2.25H4.5M12.75 9.75a.75.75 0 100-1.5.75.75 0 000 1.5zM12.75 12.75a.75.75 0 100-1.5.75.75 0 000 1.5zM12.75 15.75a.75.75 0 100-1.5.75.75 0 000 1.5z" /></svg>
                 <div>
-                  <h3 class="text-lg font-semibold text-white">Call Us</h3>
-                  <p>+1 (555) 123-4567</p>
+                  <h3 class="text-lg font-semibold text-white" data-translate-key="contactPhoneTitle">Call Us</h3>
+                  <p data-translate-key="contactPhoneValue">+1 (555) 123-4567</p>
                 </div>
               </div>
               <div class="flex items-start">
                 <svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke-width="1.5" stroke="currentColor" class="flex-shrink-0 h-6 w-6 text-brand-accent mr-3 mt-1"><path stroke-linecap="round" stroke-linejoin="round" d="M15 10.5a3 3 0 11-6 0 3 3 0 016 0z" /><path stroke-linecap="round" stroke-linejoin="round" d="M19.5 10.5c0 7.142-7.5 11.25-7.5 11.25S4.5 17.642 4.5 10.5a7.5 7.5 0 1115 0z" /></svg>
                 <div>
-                  <h3 class="text-lg font-semibold text-white">Visit Us</h3>
-                  <p>123 Drone Lane, Innovation City, CA 90210</p>
+                  <h3 class="text-lg font-semibold text-white" data-translate-key="contactAddressTitle">Visit Us</h3>
+                  <p data-translate-key="contactAddressValue">123 Drone Lane, Innovation City, CA 90210</p>
                 </div>
               </div>
             </div>
@@ -207,6 +208,7 @@
                 allowfullscreen="" 
                 loading="lazy"
                 title="Company Location"
+                data-translate-key="mapTitle"
                 class="filter grayscale contrast-120 opacity-75"
               ></iframe>
             </div>
@@ -218,7 +220,7 @@
 
   <footer class="bg-brand-secondary text-brand-text py-8">
     <div class="max-w-7xl mx-auto px-4 sm:px-6 lg:px-8 text-center">
-      <p><span data-translate-key="footerRights">&copy; <span id="current-year"></span> Millenium Drones. All rights reserved.</span></p>
+      <p><span data-translate-key="footerRights">&copy; <span id="current-year"></span> SOLA. All rights reserved.</span></p>
       <p class="text-sm mt-1" data-translate-key="footerSlogan">Pioneering the Future of Aerial Technology.</p>
     </div>
   </footer>

--- a/index.html
+++ b/index.html
@@ -3,7 +3,7 @@
 <head>
   <meta charset="UTF-8">
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
-  <title>Millenium Drones - Home</title>
+  <title>SOLA - Home</title>
   <script src="https://cdn.tailwindcss.com"></script>
   <script>
     tailwind.config = {
@@ -59,7 +59,7 @@
               <path stroke-linecap="round" stroke-linejoin="round" d="M12.75 3.03v.568c0 .334.148.65.405.85l.708.707a2.25 2.25 0 010 3.182L11.53 10.53a2.25 2.25 0 01-3.182 0L6.272 8.455a2.25 2.25 0 010-3.182L7.025 4.48c.205-.2.518-.303.85-.303h.568a2.25 2.25 0 002.25-2.25v-.568c0-.334.148.65.405-.85L12 2.25l.708.707a1.125 1.125 0 00.85.405h.568c1.24 0 2.25 1.01 2.25 2.25v.568c0 .334-.148.65-.405.85l-.708.707a2.25 2.25 0 000 3.182l2.473 2.472a2.25 2.25 0 003.182 0l.707-.707c.257-.257.405-.596.405-.955V8.25a2.25 2.25 0 00-2.25-2.25h-.568a1.125 1.125 0 00-.85.405L15.75 6.75v-.568a2.25 2.25 0 00-2.25-2.25h-.568A1.125 1.125 0 0012.75 3.03z" />
               <path stroke-linecap="round" stroke-linejoin="round" d="M6 18H4.5a2.25 2.25 0 01-2.25-2.25V13.5A2.25 2.25 0 014.5 11.25H6M18 18h1.5a2.25 2.25 0 002.25-2.25V13.5A2.25 2.25 0 0019.5 11.25H18M12 12.75V21m0 0H9.75M12 21h2.25" />
             </svg>
-            <span class="font-bold text-2xl tracking-tight" data-translate-key="heroTitle1">Millenium Drones</span>
+            <span class="font-bold text-2xl tracking-tight" data-translate-key="heroTitle1">SOLA</span>
             <!-- Also heroTitle1, but this is the nav branding -->
           </a>
         </div>
@@ -125,7 +125,7 @@
       <div class="relative max-w-7xl mx-auto py-24 px-4 sm:py-32 sm:px-6 lg:px-8">
         <div class="text-center lg:text-left">
           <h1 class="text-4xl font-extrabold tracking-tight text-white sm:text-5xl md:text-6xl">
-            <span class="block" data-translate-key="heroTitle1">Millenium Drones</span>
+            <span class="block" data-translate-key="heroTitle1">SOLA</span>
             <span class="block text-brand-accent mt-2" data-translate-key="heroTitle2">Elevate Your Perspective</span>
           </h1>
           <p class="mt-6 max-w-md mx-auto text-lg text-brand-text sm:text-xl md:mt-8 md:max-w-3xl lg:mx-0" data-translate-key="heroDescription">
@@ -159,17 +159,18 @@
     <section class="py-16 lg:py-24 bg-brand-secondary">
       <div class="max-w-7xl mx-auto px-4 sm:px-6 lg:px-8">
         <div class="lg:text-center">
-          <h2 class="text-base text-brand-accent font-semibold tracking-wide uppercase">Who We Are</h2>
-          <p class="mt-2 text-3xl leading-8 font-extrabold tracking-tight text-white sm:text-4xl">
-            Innovating the Skies with Millenium Drones
+          <h2 class="text-base text-brand-accent font-semibold tracking-wide uppercase" data-translate-key="aboutTeaserTitle">Who We Are</h2>
+          <p class="mt-2 text-3xl leading-8 font-extrabold tracking-tight text-white sm:text-4xl" data-translate-key="aboutTeaserSlogan">
+            Innovating the Skies with SOLA
           </p>
-          <p class="mt-4 max-w-2xl text-xl text-brand-text lg:mx-auto">
+          <p class="mt-4 max-w-2xl text-xl text-brand-text lg:mx-auto" data-translate-key="aboutTeaserDescription">
             We are dedicated to designing and manufacturing state-of-the-art drones that push the boundaries of aerial technology. Our commitment is to quality, reliability, and innovation.
           </p>
           <div class="mt-6">
             <a 
               href="./about.html" 
               class="text-brand-accent hover:text-opacity-80 font-semibold text-lg transition-colors duration-150"
+              data-translate-key="aboutTeaserLink"
             >
               Learn more about us &rarr;
             </a>
@@ -182,8 +183,8 @@
     <section class="py-16 lg:py-24 bg-brand-primary">
       <div class="max-w-7xl mx-auto px-4 sm:px-6 lg:px-8">
         <div class="text-center mb-12">
-          <h2 class="text-3xl font-extrabold tracking-tight text-white sm:text-4xl">Our Flagship Drones</h2>
-          <p class="mt-4 text-xl text-brand-text">
+          <h2 class="text-3xl font-extrabold tracking-tight text-white sm:text-4xl" data-translate-key="productsHighlightTitle">Our Flagship Drones</h2>
+          <p class="mt-4 text-xl text-brand-text" data-translate-key="productsHighlightSlogan">
             Engineered for performance, built for reliability.
           </p>
         </div>
@@ -192,19 +193,19 @@
           <div class="bg-brand-secondary rounded-lg shadow-xl overflow-hidden flex flex-col h-full transform hover:scale-105 transition-transform duration-300 ease-in-out">
             <img class="w-full h-56 object-cover" src="https://picsum.photos/seed/falconX1/600/400" alt="Millenium Falcon X1">
             <div class="p-6 flex flex-col flex-grow">
-              <h3 class="text-2xl font-semibold text-white mb-2">Millenium Falcon X1</h3>
-              <p class="text-brand-text text-sm mb-4 flex-grow">High-performance surveillance and reconnaissance drone with extended flight time and advanced optics.</p>
+              <h3 class="text-2xl font-semibold text-white mb-2" data-translate-key="productFalconName">SOLA Falcon X1</h3>
+              <p class="text-brand-text text-sm mb-4 flex-grow" data-translate-key="productFalconDescription">High-performance surveillance and reconnaissance drone with extended flight time and advanced optics.</p>
               <div class="mb-4">
-                <h4 class="text-sm font-semibold text-brand-accent mb-2">Key Specs:</h4>
+                <h4 class="text-sm font-semibold text-brand-accent mb-2" data-translate-key="productKeySpecs">Key Specs:</h4>
                 <ul class="space-y-1 text-xs text-brand-text">
-                  <li class="flex items-center"><svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke-width="1.5" stroke="currentColor" class="w-4 h-4 mr-2 text-brand-accent flex-shrink-0"><path stroke-linecap="round" stroke-linejoin="round" d="M6.827 6.175A2.31 2.31 0 015.186 7.23c-.38.054-.757.112-1.134.175C2.999 7.58 2.25 8.507 2.25 9.574V18a2.25 2.25 0 002.25 2.25h15A2.25 2.25 0 0021.75 18V9.574c0-1.067-.75-1.994-1.802-2.169a47.865 47.865 0 00-1.134-.175 2.31 2.31 0 01-1.64-1.055l-.822-1.316a2.192 2.192 0 00-1.736-1.039 48.774 48.774 0 00-5.232 0 2.192 2.192 0 00-1.736 1.039l-.821 1.316z" /><path stroke-linecap="round" stroke-linejoin="round" d="M16.5 12.75a4.5 4.5 0 11-9 0 4.5 4.5 0 019 0zM18.75 10.5h.008v.008h-.008V10.5z" /></svg><span>4K HDR Camera</span></li>
-                  <li class="flex items-center"><svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke-width="1.5" stroke="currentColor" class="w-4 h-4 mr-2 text-brand-accent flex-shrink-0"><path stroke-linecap="round" stroke-linejoin="round" d="M21 10.5V6.75a2.25 2.25 0 00-2.25-2.25H5.25A2.25 2.25 0 003 6.75v10.5A2.25 2.25 0 005.25 19.5h13.5A2.25 2.25 0 0021 17.25V13.5M19.5 10.5v3m0 0H4.5m15 0v-3m0 0H4.5" /><path stroke-linecap="round" stroke-linejoin="round" d="M15.75 6.75h.008v.008h-.008V6.75z" /></svg><span>55 Min Flight Time</span></li>
-                  <li class="flex items-center"><svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke-width="1.5" stroke="currentColor" class="w-4 h-4 mr-2 text-brand-accent flex-shrink-0"><path stroke-linecap="round" stroke-linejoin="round" d="M8.25 4.5l7.5 7.5-7.5 7.5" /><path stroke-linecap="round" stroke-linejoin="round" d="M3.75 4.5l7.5 7.5-7.5 7.5" /></svg><span>10km Range</span></li>
+                  <li class="flex items-center"><svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke-width="1.5" stroke="currentColor" class="w-4 h-4 mr-2 text-brand-accent flex-shrink-0"><path stroke-linecap="round" stroke-linejoin="round" d="M6.827 6.175A2.31 2.31 0 015.186 7.23c-.38.054-.757.112-1.134.175C2.999 7.58 2.25 8.507 2.25 9.574V18a2.25 2.25 0 002.25 2.25h15A2.25 2.25 0 0021.75 18V9.574c0-1.067-.75-1.994-1.802-2.169a47.865 47.865 0 00-1.134-.175 2.31 2.31 0 01-1.64-1.055l-.822-1.316a2.192 2.192 0 00-1.736-1.039 48.774 48.774 0 00-5.232 0 2.192 2.192 0 00-1.736 1.039l-.821 1.316z" /><path stroke-linecap="round" stroke-linejoin="round" d="M16.5 12.75a4.5 4.5 0 11-9 0 4.5 4.5 0 019 0zM18.75 10.5h.008v.008h-.008V10.5z" /></svg><span data-translate-key="productFalconSpecCamera">4K HDR Camera</span></li>
+                  <li class="flex items-center"><svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke-width="1.5" stroke="currentColor" class="w-4 h-4 mr-2 text-brand-accent flex-shrink-0"><path stroke-linecap="round" stroke-linejoin="round" d="M21 10.5V6.75a2.25 2.25 0 00-2.25-2.25H5.25A2.25 2.25 0 003 6.75v10.5A2.25 2.25 0 005.25 19.5h13.5A2.25 2.25 0 0021 17.25V13.5M19.5 10.5v3m0 0H4.5m15 0v-3m0 0H4.5" /><path stroke-linecap="round" stroke-linejoin="round" d="M15.75 6.75h.008v.008h-.008V6.75z" /></svg><span data-translate-key="productFalconSpecFlight">55 Min Flight Time</span></li>
+                  <li class="flex items-center"><svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke-width="1.5" stroke="currentColor" class="w-4 h-4 mr-2 text-brand-accent flex-shrink-0"><path stroke-linecap="round" stroke-linejoin="round" d="M8.25 4.5l7.5 7.5-7.5 7.5" /><path stroke-linecap="round" stroke-linejoin="round" d="M3.75 4.5l7.5 7.5-7.5 7.5" /></svg><span data-translate-key="productFalconSpecRange">10km Range</span></li>
                 </ul>
               </div>
-              <p class="text-2xl font-bold text-brand-accent mb-4">$2,499</p>
+              <p class="text-2xl font-bold text-brand-accent mb-4" data-translate-key="productFalconPrice">$2,499</p>
               <div class="mt-auto">
-                <button class="w-full bg-brand-accent text-brand-primary font-semibold py-2 px-4 rounded-md hover:bg-opacity-80 transition-colors duration-150" onclick="showProductDetails('Millenium Falcon X1')">View Details</button>
+                <button class="w-full bg-brand-accent text-brand-primary font-semibold py-2 px-4 rounded-md hover:bg-opacity-80 transition-colors duration-150" onclick="showProductDetails('SOLA Falcon X1')" data-translate-key="productViewDetailsBtn">View Details</button>
               </div>
             </div>
           </div>
@@ -212,19 +213,19 @@
           <div class="bg-brand-secondary rounded-lg shadow-xl overflow-hidden flex flex-col h-full transform hover:scale-105 transition-transform duration-300 ease-in-out">
             <img class="w-full h-56 object-cover" src="https://picsum.photos/seed/sparrowZ3/600/400" alt="Millenium Sparrow Z3">
             <div class="p-6 flex flex-col flex-grow">
-              <h3 class="text-2xl font-semibold text-white mb-2">Millenium Sparrow Z3</h3>
-              <p class="text-brand-text text-sm mb-4 flex-grow">Compact and agile drone perfect for aerial photography and videography enthusiasts.</p>
+              <h3 class="text-2xl font-semibold text-white mb-2" data-translate-key="productSparrowName">SOLA Sparrow Z3</h3>
+              <p class="text-brand-text text-sm mb-4 flex-grow" data-translate-key="productSparrowDescription">Compact and agile drone perfect for aerial photography and videography enthusiasts.</p>
               <div class="mb-4">
-                <h4 class="text-sm font-semibold text-brand-accent mb-2">Key Specs:</h4>
+                <h4 class="text-sm font-semibold text-brand-accent mb-2" data-translate-key="productKeySpecs">Key Specs:</h4>
                 <ul class="space-y-1 text-xs text-brand-text">
-                  <li class="flex items-center"><svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke-width="1.5" stroke="currentColor" class="w-4 h-4 mr-2 text-brand-accent flex-shrink-0"><path stroke-linecap="round" stroke-linejoin="round" d="M6.827 6.175A2.31 2.31 0 015.186 7.23c-.38.054-.757.112-1.134.175C2.999 7.58 2.25 8.507 2.25 9.574V18a2.25 2.25 0 002.25 2.25h15A2.25 2.25 0 0021.75 18V9.574c0-1.067-.75-1.994-1.802-2.169a47.865 47.865 0 00-1.134-.175 2.31 2.31 0 01-1.64-1.055l-.822-1.316a2.192 2.192 0 00-1.736-1.039 48.774 48.774 0 00-5.232 0 2.192 2.192 0 00-1.736 1.039l-.821 1.316z" /><path stroke-linecap="round" stroke-linejoin="round" d="M16.5 12.75a4.5 4.5 0 11-9 0 4.5 4.5 0 019 0zM18.75 10.5h.008v.008h-.008V10.5z" /></svg><span>2.7K Camera</span></li>
-                  <li class="flex items-center"><svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke-width="1.5" stroke="currentColor" class="w-4 h-4 mr-2 text-brand-accent flex-shrink-0"><path stroke-linecap="round" stroke-linejoin="round" d="M21 10.5V6.75a2.25 2.25 0 00-2.25-2.25H5.25A2.25 2.25 0 003 6.75v10.5A2.25 2.25 0 005.25 19.5h13.5A2.25 2.25 0 0021 17.25V13.5M19.5 10.5v3m0 0H4.5m15 0v-3m0 0H4.5" /><path stroke-linecap="round" stroke-linejoin="round" d="M15.75 6.75h.008v.008h-.008V6.75z" /></svg><span>30 Min Flight Time</span></li>
-                  <li class="flex items-center"><svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke-width="1.5" stroke="currentColor" class="w-4 h-4 mr-2 text-brand-accent flex-shrink-0"><path stroke-linecap="round" stroke-linejoin="round" d="M8.25 4.5l7.5 7.5-7.5 7.5" /><path stroke-linecap="round" stroke-linejoin="round" d="M3.75 4.5l7.5 7.5-7.5 7.5" /></svg><span>5km Range</span></li>
+                  <li class="flex items-center"><svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke-width="1.5" stroke="currentColor" class="w-4 h-4 mr-2 text-brand-accent flex-shrink-0"><path stroke-linecap="round" stroke-linejoin="round" d="M6.827 6.175A2.31 2.31 0 015.186 7.23c-.38.054-.757.112-1.134.175C2.999 7.58 2.25 8.507 2.25 9.574V18a2.25 2.25 0 002.25 2.25h15A2.25 2.25 0 0021.75 18V9.574c0-1.067-.75-1.994-1.802-2.169a47.865 47.865 0 00-1.134-.175 2.31 2.31 0 01-1.64-1.055l-.822-1.316a2.192 2.192 0 00-1.736-1.039 48.774 48.774 0 00-5.232 0 2.192 2.192 0 00-1.736 1.039l-.821 1.316z" /><path stroke-linecap="round" stroke-linejoin="round" d="M16.5 12.75a4.5 4.5 0 11-9 0 4.5 4.5 0 019 0zM18.75 10.5h.008v.008h-.008V10.5z" /></svg><span data-translate-key="productSparrowSpecCamera">2.7K Camera</span></li>
+                  <li class="flex items-center"><svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke-width="1.5" stroke="currentColor" class="w-4 h-4 mr-2 text-brand-accent flex-shrink-0"><path stroke-linecap="round" stroke-linejoin="round" d="M21 10.5V6.75a2.25 2.25 0 00-2.25-2.25H5.25A2.25 2.25 0 003 6.75v10.5A2.25 2.25 0 005.25 19.5h13.5A2.25 2.25 0 0021 17.25V13.5M19.5 10.5v3m0 0H4.5m15 0v-3m0 0H4.5" /><path stroke-linecap="round" stroke-linejoin="round" d="M15.75 6.75h.008v.008h-.008V6.75z" /></svg><span data-translate-key="productSparrowSpecFlight">30 Min Flight Time</span></li>
+                  <li class="flex items-center"><svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke-width="1.5" stroke="currentColor" class="w-4 h-4 mr-2 text-brand-accent flex-shrink-0"><path stroke-linecap="round" stroke-linejoin="round" d="M8.25 4.5l7.5 7.5-7.5 7.5" /><path stroke-linecap="round" stroke-linejoin="round" d="M3.75 4.5l7.5 7.5-7.5 7.5" /></svg><span data-translate-key="productSparrowSpecRange">5km Range</span></li>
                 </ul>
               </div>
-              <p class="text-2xl font-bold text-brand-accent mb-4">$899</p>
+              <p class="text-2xl font-bold text-brand-accent mb-4" data-translate-key="productSparrowPrice">$899</p>
               <div class="mt-auto">
-                <button class="w-full bg-brand-accent text-brand-primary font-semibold py-2 px-4 rounded-md hover:bg-opacity-80 transition-colors duration-150" onclick="showProductDetails('Millenium Sparrow Z3')">View Details</button>
+                <button class="w-full bg-brand-accent text-brand-primary font-semibold py-2 px-4 rounded-md hover:bg-opacity-80 transition-colors duration-150" onclick="showProductDetails('SOLA Sparrow Z3')" data-translate-key="productViewDetailsBtn">View Details</button>
               </div>
             </div>
           </div>
@@ -232,19 +233,19 @@
           <div class="bg-brand-secondary rounded-lg shadow-xl overflow-hidden flex flex-col h-full transform hover:scale-105 transition-transform duration-300 ease-in-out">
             <img class="w-full h-56 object-cover" src="https://picsum.photos/seed/eaglePro/600/400" alt="Millenium Eagle Pro">
             <div class="p-6 flex flex-col flex-grow">
-              <h3 class="text-2xl font-semibold text-white mb-2">Millenium Eagle Pro</h3>
-              <p class="text-brand-text text-sm mb-4 flex-grow">Professional-grade drone for industrial inspections and mapping solutions.</p>
+              <h3 class="text-2xl font-semibold text-white mb-2" data-translate-key="productEagleName">SOLA Eagle Pro</h3>
+              <p class="text-brand-text text-sm mb-4 flex-grow" data-translate-key="productEagleDescription">Professional-grade drone for industrial inspections and mapping solutions.</p>
               <div class="mb-4">
-                <h4 class="text-sm font-semibold text-brand-accent mb-2">Key Specs:</h4>
+                <h4 class="text-sm font-semibold text-brand-accent mb-2" data-translate-key="productKeySpecs">Key Specs:</h4>
                 <ul class="space-y-1 text-xs text-brand-text">
-                  <li class="flex items-center"><svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke-width="1.5" stroke="currentColor" class="w-4 h-4 mr-2 text-brand-accent flex-shrink-0"><path stroke-linecap="round" stroke-linejoin="round" d="M6.827 6.175A2.31 2.31 0 015.186 7.23c-.38.054-.757.112-1.134.175C2.999 7.58 2.25 8.507 2.25 9.574V18a2.25 2.25 0 002.25 2.25h15A2.25 2.25 0 0021.75 18V9.574c0-1.067-.75-1.994-1.802-2.169a47.865 47.865 0 00-1.134-.175 2.31 2.31 0 01-1.64-1.055l-.822-1.316a2.192 2.192 0 00-1.736-1.039 48.774 48.774 0 00-5.232 0 2.192 2.192 0 00-1.736 1.039l-.821 1.316z" /><path stroke-linecap="round" stroke-linejoin="round" d="M16.5 12.75a4.5 4.5 0 11-9 0 4.5 4.5 0 019 0zM18.75 10.5h.008v.008h-.008V10.5z" /></svg><span>Thermal Imaging</span></li>
-                  <li class="flex items-center"><svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke-width="1.5" stroke="currentColor" class="w-4 h-4 mr-2 text-brand-accent flex-shrink-0"><path stroke-linecap="round" stroke-linejoin="round" d="M21 10.5V6.75a2.25 2.25 0 00-2.25-2.25H5.25A2.25 2.25 0 003 6.75v10.5A2.25 2.25 0 005.25 19.5h13.5A2.25 2.25 0 0021 17.25V13.5M19.5 10.5v3m0 0H4.5m15 0v-3m0 0H4.5" /><path stroke-linecap="round" stroke-linejoin="round" d="M15.75 6.75h.008v.008h-.008V6.75z" /></svg><span>RTK Precision</span></li>
-                  <li class="flex items-center"><svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke-width="1.5" stroke="currentColor" class="w-4 h-4 mr-2 text-brand-accent flex-shrink-0"><path stroke-linecap="round" stroke-linejoin="round" d="M8.25 4.5l7.5 7.5-7.5 7.5" /><path stroke-linecap="round" stroke-linejoin="round" d="M3.75 4.5l7.5 7.5-7.5 7.5" /></svg><span>70 Min Flight Time</span></li>
+                  <li class="flex items-center"><svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke-width="1.5" stroke="currentColor" class="w-4 h-4 mr-2 text-brand-accent flex-shrink-0"><path stroke-linecap="round" stroke-linejoin="round" d="M6.827 6.175A2.31 2.31 0 015.186 7.23c-.38.054-.757.112-1.134.175C2.999 7.58 2.25 8.507 2.25 9.574V18a2.25 2.25 0 002.25 2.25h15A2.25 2.25 0 0021.75 18V9.574c0-1.067-.75-1.994-1.802-2.169a47.865 47.865 0 00-1.134-.175 2.31 2.31 0 01-1.64-1.055l-.822-1.316a2.192 2.192 0 00-1.736-1.039 48.774 48.774 0 00-5.232 0 2.192 2.192 0 00-1.736 1.039l-.821 1.316z" /><path stroke-linecap="round" stroke-linejoin="round" d="M16.5 12.75a4.5 4.5 0 11-9 0 4.5 4.5 0 019 0zM18.75 10.5h.008v.008h-.008V10.5z" /></svg><span data-translate-key="productEagleSpecImaging">Thermal Imaging</span></li>
+                  <li class="flex items-center"><svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke-width="1.5" stroke="currentColor" class="w-4 h-4 mr-2 text-brand-accent flex-shrink-0"><path stroke-linecap="round" stroke-linejoin="round" d="M21 10.5V6.75a2.25 2.25 0 00-2.25-2.25H5.25A2.25 2.25 0 003 6.75v10.5A2.25 2.25 0 005.25 19.5h13.5A2.25 2.25 0 0021 17.25V13.5M19.5 10.5v3m0 0H4.5m15 0v-3m0 0H4.5" /><path stroke-linecap="round" stroke-linejoin="round" d="M15.75 6.75h.008v.008h-.008V6.75z" /></svg><span data-translate-key="productEagleSpecPrecision">RTK Precision</span></li>
+                  <li class="flex items-center"><svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke-width="1.5" stroke="currentColor" class="w-4 h-4 mr-2 text-brand-accent flex-shrink-0"><path stroke-linecap="round" stroke-linejoin="round" d="M8.25 4.5l7.5 7.5-7.5 7.5" /><path stroke-linecap="round" stroke-linejoin="round" d="M3.75 4.5l7.5 7.5-7.5 7.5" /></svg><span data-translate-key="productEagleSpecFlight">70 Min Flight Time</span></li>
                 </ul>
               </div>
-              <p class="text-2xl font-bold text-brand-accent mb-4">$7,999</p>
+              <p class="text-2xl font-bold text-brand-accent mb-4" data-translate-key="productEaglePrice">$7,999</p>
               <div class="mt-auto">
-                <button class="w-full bg-brand-accent text-brand-primary font-semibold py-2 px-4 rounded-md hover:bg-opacity-80 transition-colors duration-150" onclick="showProductDetails('Millenium Eagle Pro')">View Details</button>
+                <button class="w-full bg-brand-accent text-brand-primary font-semibold py-2 px-4 rounded-md hover:bg-opacity-80 transition-colors duration-150" onclick="showProductDetails('SOLA Eagle Pro')" data-translate-key="productViewDetailsBtn">View Details</button>
               </div>
             </div>
           </div>
@@ -253,6 +254,7 @@
             <a 
               href="./products.html" 
               class="inline-block bg-brand-accent text-brand-primary font-semibold py-3 px-8 rounded-md hover:bg-opacity-80 transition-colors duration-150 text-lg"
+              data-translate-key="viewAllDronesBtn"
             >
               View All Drones
             </a>
@@ -264,8 +266,8 @@
     <section class="py-16 lg:py-24 bg-brand-secondary">
       <div class="max-w-7xl mx-auto px-4 sm:px-6 lg:px-8">
         <div class="text-center mb-12">
-          <h2 class="text-3xl font-extrabold tracking-tight text-white sm:text-4xl">Why Choose Millenium?</h2>
-          <p class="mt-4 text-xl text-brand-text">
+          <h2 class="text-3xl font-extrabold tracking-tight text-white sm:text-4xl" data-translate-key="featuresTitle">Why Choose SOLA?</h2>
+          <p class="mt-4 text-xl text-brand-text" data-translate-key="featuresSlogan">
             Experience the difference with our advanced drone technology.
           </p>
         </div>
@@ -275,24 +277,24 @@
             <div class="mb-4 text-brand-accent">
               <svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke-width="1.5" stroke="currentColor" class="w-16 h-16"><path stroke-linecap="round" stroke-linejoin="round" d="M8.25 4.5l7.5 7.5-7.5 7.5" /><path stroke-linecap="round" stroke-linejoin="round" d="M3.75 4.5l7.5 7.5-7.5 7.5" /></svg>
             </div>
-            <h3 class="text-xl font-semibold text-white mb-2">Extended Range</h3>
-            <p class="text-brand-text text-sm">Our drones boast impressive operational ranges, allowing you to cover more ground.</p>
+            <h3 class="text-xl font-semibold text-white mb-2" data-translate-key="featureExtendedRangeTitle">Extended Range</h3>
+            <p class="text-brand-text text-sm" data-translate-key="featureExtendedRangeDesc">Our drones boast impressive operational ranges, allowing you to cover more ground.</p>
           </div>
           <!-- Feature Card 2: Superior Battery Life -->
           <div class="bg-brand-primary p-6 rounded-lg shadow-lg text-center h-full flex flex-col items-center">
             <div class="mb-4 text-brand-accent">
               <svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke-width="1.5" stroke="currentColor" class="w-16 h-16"><path stroke-linecap="round" stroke-linejoin="round" d="M21 10.5V6.75a2.25 2.25 0 00-2.25-2.25H5.25A2.25 2.25 0 003 6.75v10.5A2.25 2.25 0 005.25 19.5h13.5A2.25 2.25 0 0021 17.25V13.5M19.5 10.5v3m0 0H4.5m15 0v-3m0 0H4.5" /><path stroke-linecap="round" stroke-linejoin="round" d="M15.75 6.75h.008v.008h-.008V6.75z" /></svg>
             </div>
-            <h3 class="text-xl font-semibold text-white mb-2">Superior Battery Life</h3>
-            <p class="text-brand-text text-sm">Fly longer and capture more with our high-capacity, intelligent battery systems.</p>
+            <h3 class="text-xl font-semibold text-white mb-2" data-translate-key="featureBatteryLifeTitle">Superior Battery Life</h3>
+            <p class="text-brand-text text-sm" data-translate-key="featureBatteryLifeDesc">Fly longer and capture more with our high-capacity, intelligent battery systems.</p>
           </div>
           <!-- Feature Card 3: Advanced Optics -->
           <div class="bg-brand-primary p-6 rounded-lg shadow-lg text-center h-full flex flex-col items-center">
             <div class="mb-4 text-brand-accent">
               <svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke-width="1.5" stroke="currentColor" class="w-16 h-16"><path stroke-linecap="round" stroke-linejoin="round" d="M6.827 6.175A2.31 2.31 0 015.186 7.23c-.38.054-.757.112-1.134.175C2.999 7.58 2.25 8.507 2.25 9.574V18a2.25 2.25 0 002.25 2.25h15A2.25 2.25 0 0021.75 18V9.574c0-1.067-.75-1.994-1.802-2.169a47.865 47.865 0 00-1.134-.175 2.31 2.31 0 01-1.64-1.055l-.822-1.316a2.192 2.192 0 00-1.736-1.039 48.774 48.774 0 00-5.232 0 2.192 2.192 0 00-1.736 1.039l-.821 1.316z" /><path stroke-linecap="round" stroke-linejoin="round" d="M16.5 12.75a4.5 4.5 0 11-9 0 4.5 4.5 0 019 0zM18.75 10.5h.008v.008h-.008V10.5z" /></svg>
             </div>
-            <h3 class="text-xl font-semibold text-white mb-2">Advanced Optics</h3>
-            <p class="text-brand-text text-sm">Capture stunning visuals with high-resolution cameras and state-of-the-art sensors.</p>
+            <h3 class="text-xl font-semibold text-white mb-2" data-translate-key="featureOpticsTitle">Advanced Optics</h3>
+            <p class="text-brand-text text-sm" data-translate-key="featureOpticsDesc">Capture stunning visuals with high-resolution cameras and state-of-the-art sensors.</p>
           </div>
         </div>
       </div>
@@ -302,14 +304,15 @@
     <div class="bg-brand-accent">
       <div class="max-w-4xl mx-auto py-16 px-4 sm:px-6 sm:py-24 lg:px-8 lg:flex lg:items-center lg:justify-between">
         <h2 class="text-3xl font-extrabold tracking-tight text-brand-primary sm:text-4xl">
-          <span class="block">Ready to Elevate Your Operations?</span>
-          <span class="block text-white">Explore our drone solutions today.</span>
+          <span class="block" data-translate-key="ctaTitle">Ready to Elevate Your Operations?</span>
+          <span class="block text-white" data-translate-key="ctaSlogan">Explore our drone solutions today.</span>
         </h2>
         <div class="mt-8 flex lg:mt-0 lg:flex-shrink-0">
           <div class="inline-flex rounded-md shadow">
             <a
               href="./products.html"
               class="inline-flex items-center justify-center px-6 py-3 border border-transparent text-base font-medium rounded-md text-brand-accent bg-white hover:bg-gray-100 transition-colors duration-150"
+              data-translate-key="ctaViewOurDrones"
             >
               View Our Drones
             </a>
@@ -318,6 +321,7 @@
             <a
               href="./contact.html"
               class="inline-flex items-center justify-center px-6 py-3 border border-transparent text-base font-medium rounded-md text-white bg-brand-primary hover:bg-opacity-90 transition-colors duration-150"
+              data-translate-key="ctaContactSalesBtn"
             >
               Contact Sales
             </a>
@@ -329,7 +333,7 @@
 
   <footer class="bg-brand-secondary text-brand-text py-8">
     <div class="max-w-7xl mx-auto px-4 sm:px-6 lg:px-8 text-center">
-      <p><span data-translate-key="footerRights">&copy; <span id="current-year"></span> Millenium Drones. All rights reserved.</span></p>
+      <p><span data-translate-key="footerRights">&copy; <span id="current-year"></span> SOLA. All rights reserved.</span></p>
       <p class="text-sm mt-1" data-translate-key="footerSlogan">Pioneering the Future of Aerial Technology.</p>
     </div>
   </footer>

--- a/products.html
+++ b/products.html
@@ -3,7 +3,7 @@
 <head>
   <meta charset="UTF-8">
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
-  <title>Our Drones - Millenium Drones</title>
+  <title>Our Drones - SOLA</title>
   <script src="https://cdn.tailwindcss.com"></script>
   <script>
     tailwind.config = {
@@ -48,7 +48,7 @@
               <path stroke-linecap="round" stroke-linejoin="round" d="M12.75 3.03v.568c0 .334.148.65.405.85l.708.707a2.25 2.25 0 010 3.182L11.53 10.53a2.25 2.25 0 01-3.182 0L6.272 8.455a2.25 2.25 0 010-3.182L7.025 4.48c.205-.2.518-.303.85-.303h.568a2.25 2.25 0 002.25-2.25v-.568c0-.334.148-.65.405-.85L12 2.25l.708.707a1.125 1.125 0 00.85.405h.568c1.24 0 2.25 1.01 2.25 2.25v.568c0 .334-.148.65-.405.85l-.708.707a2.25 2.25 0 000 3.182l2.473 2.472a2.25 2.25 0 003.182 0l.707-.707c.257-.257.405-.596.405-.955V8.25a2.25 2.25 0 00-2.25-2.25h-.568a1.125 1.125 0 00-.85.405L15.75 6.75v-.568a2.25 2.25 0 00-2.25-2.25h-.568A1.125 1.125 0 0012.75 3.03z" />
               <path stroke-linecap="round" stroke-linejoin="round" d="M6 18H4.5a2.25 2.25 0 01-2.25-2.25V13.5A2.25 2.25 0 014.5 11.25H6M18 18h1.5a2.25 2.25 0 002.25-2.25V13.5A2.25 2.25 0 0019.5 11.25H18M12 12.75V21m0 0H9.75M12 21h2.25" />
             </svg>
-            <span class="font-bold text-2xl tracking-tight" data-translate-key="heroTitle1">Millenium Drones</span>
+            <span class="font-bold text-2xl tracking-tight" data-translate-key="heroTitle1">SOLA</span>
           </a>
         </div>
         <div class="hidden md:block">
@@ -103,20 +103,20 @@
     <div class="bg-brand-primary py-16 sm:py-24">
       <div class="max-w-7xl mx-auto px-4 sm:px-6 lg:px-8">
         <div class="text-center mb-16">
-          <h1 class="text-4xl font-extrabold text-white sm:text-5xl sm:tracking-tight lg:text-6xl">
+          <h1 class="text-4xl font-extrabold text-white sm:text-5xl sm:tracking-tight lg:text-6xl" data-translate-key="productsPageTitle">
             Our Drone Fleet
           </h1>
-          <p class="mt-6 max-w-3xl mx-auto text-xl text-brand-text">
+          <p class="mt-6 max-w-3xl mx-auto text-xl text-brand-text" data-translate-key="productsPageSlogan">
             Explore our comprehensive range of advanced aerial solutions, designed for diverse applications and industries.
           </p>
         </div>
 
         <div class="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-3 gap-x-8 gap-y-12">
-          <!-- Product Card 1: Millenium Falcon X1 -->
+          <!-- Product Card 1: SOLA Falcon X1 -->
           <div class="bg-brand-secondary rounded-lg shadow-xl overflow-hidden flex flex-col h-full transform hover:scale-105 transition-transform duration-300 ease-in-out">
-            <img class="w-full h-56 object-cover" src="https://picsum.photos/seed/falconX1/600/400" alt="Millenium Falcon X1">
+            <img class="w-full h-56 object-cover" src="https://picsum.photos/seed/falconX1/600/400" alt="SOLA Falcon X1">
             <div class="p-6 flex flex-col flex-grow">
-              <h3 class="text-2xl font-semibold text-white mb-2">Millenium Falcon X1</h3>
+              <h3 class="text-2xl font-semibold text-white mb-2">SOLA Falcon X1</h3>
               <p class="text-brand-text text-sm mb-4 flex-grow">High-performance surveillance and reconnaissance drone with extended flight time and advanced optics.</p>
               <div class="mb-4">
                 <h4 class="text-sm font-semibold text-brand-accent mb-2">Key Specs:</h4>
@@ -124,20 +124,20 @@
                   <li class="flex items-center"><svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke-width="1.5" stroke="currentColor" class="w-4 h-4 mr-2 text-brand-accent flex-shrink-0"><path stroke-linecap="round" stroke-linejoin="round" d="M6.827 6.175A2.31 2.31 0 015.186 7.23c-.38.054-.757.112-1.134.175C2.999 7.58 2.25 8.507 2.25 9.574V18a2.25 2.25 0 002.25 2.25h15A2.25 2.25 0 0021.75 18V9.574c0-1.067-.75-1.994-1.802-2.169a47.865 47.865 0 00-1.134-.175 2.31 2.31 0 01-1.64-1.055l-.822-1.316a2.192 2.192 0 00-1.736-1.039 48.774 48.774 0 00-5.232 0 2.192 2.192 0 00-1.736 1.039l-.821 1.316z" /><path stroke-linecap="round" stroke-linejoin="round" d="M16.5 12.75a4.5 4.5 0 11-9 0 4.5 4.5 0 019 0zM18.75 10.5h.008v.008h-.008V10.5z" /></svg><span>4K HDR Camera</span></li>
                   <li class="flex items-center"><svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke-width="1.5" stroke="currentColor" class="w-4 h-4 mr-2 text-brand-accent flex-shrink-0"><path stroke-linecap="round" stroke-linejoin="round" d="M21 10.5V6.75a2.25 2.25 0 00-2.25-2.25H5.25A2.25 2.25 0 003 6.75v10.5A2.25 2.25 0 005.25 19.5h13.5A2.25 2.25 0 0021 17.25V13.5M19.5 10.5v3m0 0H4.5m15 0v-3m0 0H4.5" /><path stroke-linecap="round" stroke-linejoin="round" d="M15.75 6.75h.008v.008h-.008V6.75z" /></svg><span>55 Min Flight Time</span></li>
                   <li class="flex items-center"><svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke-width="1.5" stroke="currentColor" class="w-4 h-4 mr-2 text-brand-accent flex-shrink-0"><path stroke-linecap="round" stroke-linejoin="round" d="M8.25 4.5l7.5 7.5-7.5 7.5" /><path stroke-linecap="round" stroke-linejoin="round" d="M3.75 4.5l7.5 7.5-7.5 7.5" /></svg><span>10km Range</span></li>
-                  <li class="flex items-center"><span>AI Object Tracking</span></li>
+                  <li class="flex items-center"><span data-translate-key="productFalconSpecAI">AI Object Tracking</span></li>
                 </ul>
               </div>
               <p class="text-2xl font-bold text-brand-accent mb-4">$2,499</p>
               <div class="mt-auto">
-                <button class="w-full bg-brand-accent text-brand-primary font-semibold py-2 px-4 rounded-md hover:bg-opacity-80 transition-colors duration-150" onclick="showProductDetails('Millenium Falcon X1')">View Details</button>
+                <button class="w-full bg-brand-accent text-brand-primary font-semibold py-2 px-4 rounded-md hover:bg-opacity-80 transition-colors duration-150" onclick="showProductDetails('SOLA Falcon X1')">View Details</button>
               </div>
             </div>
           </div>
-          <!-- Product Card 2: Millenium Sparrow Z3 -->
+          <!-- Product Card 2: SOLA Sparrow Z3 -->
           <div class="bg-brand-secondary rounded-lg shadow-xl overflow-hidden flex flex-col h-full transform hover:scale-105 transition-transform duration-300 ease-in-out">
-            <img class="w-full h-56 object-cover" src="https://picsum.photos/seed/sparrowZ3/600/400" alt="Millenium Sparrow Z3">
+            <img class="w-full h-56 object-cover" src="https://picsum.photos/seed/sparrowZ3/600/400" alt="SOLA Sparrow Z3">
             <div class="p-6 flex flex-col flex-grow">
-              <h3 class="text-2xl font-semibold text-white mb-2">Millenium Sparrow Z3</h3>
+              <h3 class="text-2xl font-semibold text-white mb-2">SOLA Sparrow Z3</h3>
               <p class="text-brand-text text-sm mb-4 flex-grow">Compact and agile drone perfect for aerial photography and videography enthusiasts.</p>
               <div class="mb-4">
                 <h4 class="text-sm font-semibold text-brand-accent mb-2">Key Specs:</h4>
@@ -145,20 +145,20 @@
                   <li class="flex items-center"><svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke-width="1.5" stroke="currentColor" class="w-4 h-4 mr-2 text-brand-accent flex-shrink-0"><path stroke-linecap="round" stroke-linejoin="round" d="M6.827 6.175A2.31 2.31 0 015.186 7.23c-.38.054-.757.112-1.134.175C2.999 7.58 2.25 8.507 2.25 9.574V18a2.25 2.25 0 002.25 2.25h15A2.25 2.25 0 0021.75 18V9.574c0-1.067-.75-1.994-1.802-2.169a47.865 47.865 0 00-1.134-.175 2.31 2.31 0 01-1.64-1.055l-.822-1.316a2.192 2.192 0 00-1.736-1.039 48.774 48.774 0 00-5.232 0 2.192 2.192 0 00-1.736 1.039l-.821 1.316z" /><path stroke-linecap="round" stroke-linejoin="round" d="M16.5 12.75a4.5 4.5 0 11-9 0 4.5 4.5 0 019 0zM18.75 10.5h.008v.008h-.008V10.5z" /></svg><span>2.7K Camera</span></li>
                   <li class="flex items-center"><svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke-width="1.5" stroke="currentColor" class="w-4 h-4 mr-2 text-brand-accent flex-shrink-0"><path stroke-linecap="round" stroke-linejoin="round" d="M21 10.5V6.75a2.25 2.25 0 00-2.25-2.25H5.25A2.25 2.25 0 003 6.75v10.5A2.25 2.25 0 005.25 19.5h13.5A2.25 2.25 0 0021 17.25V13.5M19.5 10.5v3m0 0H4.5m15 0v-3m0 0H4.5" /><path stroke-linecap="round" stroke-linejoin="round" d="M15.75 6.75h.008v.008h-.008V6.75z" /></svg><span>30 Min Flight Time</span></li>
                   <li class="flex items-center"><svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke-width="1.5" stroke="currentColor" class="w-4 h-4 mr-2 text-brand-accent flex-shrink-0"><path stroke-linecap="round" stroke-linejoin="round" d="M8.25 4.5l7.5 7.5-7.5 7.5" /><path stroke-linecap="round" stroke-linejoin="round" d="M3.75 4.5l7.5 7.5-7.5 7.5" /></svg><span>5km Range</span></li>
-                  <li class="flex items-center"><span>Lightweight Design</span></li>
+                  <li class="flex items-center"><span data-translate-key="productSparrowSpecDesign">Lightweight Design</span></li>
                 </ul>
               </div>
               <p class="text-2xl font-bold text-brand-accent mb-4">$899</p>
               <div class="mt-auto">
-                <button class="w-full bg-brand-accent text-brand-primary font-semibold py-2 px-4 rounded-md hover:bg-opacity-80 transition-colors duration-150" onclick="showProductDetails('Millenium Sparrow Z3')">View Details</button>
+                <button class="w-full bg-brand-accent text-brand-primary font-semibold py-2 px-4 rounded-md hover:bg-opacity-80 transition-colors duration-150" onclick="showProductDetails('SOLA Sparrow Z3')">View Details</button>
               </div>
             </div>
           </div>
-          <!-- Product Card 3: Millenium Eagle Pro -->
+          <!-- Product Card 3: SOLA Eagle Pro -->
           <div class="bg-brand-secondary rounded-lg shadow-xl overflow-hidden flex flex-col h-full transform hover:scale-105 transition-transform duration-300 ease-in-out">
-            <img class="w-full h-56 object-cover" src="https://picsum.photos/seed/eaglePro/600/400" alt="Millenium Eagle Pro">
+            <img class="w-full h-56 object-cover" src="https://picsum.photos/seed/eaglePro/600/400" alt="SOLA Eagle Pro">
             <div class="p-6 flex flex-col flex-grow">
-              <h3 class="text-2xl font-semibold text-white mb-2">Millenium Eagle Pro</h3>
+              <h3 class="text-2xl font-semibold text-white mb-2">SOLA Eagle Pro</h3>
               <p class="text-brand-text text-sm mb-4 flex-grow">Professional-grade drone for industrial inspections and mapping solutions.</p>
               <div class="mb-4">
                 <h4 class="text-sm font-semibold text-brand-accent mb-2">Key Specs:</h4>
@@ -166,47 +166,48 @@
                   <li class="flex items-center"><svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke-width="1.5" stroke="currentColor" class="w-4 h-4 mr-2 text-brand-accent flex-shrink-0"><path stroke-linecap="round" stroke-linejoin="round" d="M6.827 6.175A2.31 2.31 0 015.186 7.23c-.38.054-.757.112-1.134.175C2.999 7.58 2.25 8.507 2.25 9.574V18a2.25 2.25 0 002.25 2.25h15A2.25 2.25 0 0021.75 18V9.574c0-1.067-.75-1.994-1.802-2.169a47.865 47.865 0 00-1.134-.175 2.31 2.31 0 01-1.64-1.055l-.822-1.316a2.192 2.192 0 00-1.736-1.039 48.774 48.774 0 00-5.232 0 2.192 2.192 0 00-1.736 1.039l-.821 1.316z" /><path stroke-linecap="round" stroke-linejoin="round" d="M16.5 12.75a4.5 4.5 0 11-9 0 4.5 4.5 0 019 0zM18.75 10.5h.008v.008h-.008V10.5z" /></svg><span>Thermal Imaging</span></li>
                   <li class="flex items-center"><svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke-width="1.5" stroke="currentColor" class="w-4 h-4 mr-2 text-brand-accent flex-shrink-0"><path stroke-linecap="round" stroke-linejoin="round" d="M21 10.5V6.75a2.25 2.25 0 00-2.25-2.25H5.25A2.25 2.25 0 003 6.75v10.5A2.25 2.25 0 005.25 19.5h13.5A2.25 2.25 0 0021 17.25V13.5M19.5 10.5v3m0 0H4.5m15 0v-3m0 0H4.5" /><path stroke-linecap="round" stroke-linejoin="round" d="M15.75 6.75h.008v.008h-.008V6.75z" /></svg><span>RTK Precision</span></li>
                   <li class="flex items-center"><svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke-width="1.5" stroke="currentColor" class="w-4 h-4 mr-2 text-brand-accent flex-shrink-0"><path stroke-linecap="round" stroke-linejoin="round" d="M8.25 4.5l7.5 7.5-7.5 7.5" /><path stroke-linecap="round" stroke-linejoin="round" d="M3.75 4.5l7.5 7.5-7.5 7.5" /></svg><span>70 Min Flight Time</span></li>
-                  <li class="flex items-center"><span>Weather Resistant</span></li>
+                  <li class="flex items-center"><span data-translate-key="productEagleSpecWeather">Weather Resistant</span></li>
                 </ul>
               </div>
               <p class="text-2xl font-bold text-brand-accent mb-4">$7,999</p>
               <div class="mt-auto">
-                <button class="w-full bg-brand-accent text-brand-primary font-semibold py-2 px-4 rounded-md hover:bg-opacity-80 transition-colors duration-150" onclick="showProductDetails('Millenium Eagle Pro')">View Details</button>
+                <button class="w-full bg-brand-accent text-brand-primary font-semibold py-2 px-4 rounded-md hover:bg-opacity-80 transition-colors duration-150" onclick="showProductDetails('SOLA Eagle Pro')">View Details</button>
               </div>
             </div>
           </div>
-          <!-- Product Card 4: Millenium Hawk V2 -->
+          <!-- Product Card 4: SOLA Hawk V2 -->
           <div class="bg-brand-secondary rounded-lg shadow-xl overflow-hidden flex flex-col h-full transform hover:scale-105 transition-transform duration-300 ease-in-out">
-            <img class="w-full h-56 object-cover" src="https://picsum.photos/seed/hawkV2/600/400" alt="Millenium Hawk V2">
+            <img class="w-full h-56 object-cover" src="https://picsum.photos/seed/hawkV2/600/400" alt="SOLA Hawk V2">
             <div class="p-6 flex flex-col flex-grow">
-              <h3 class="text-2xl font-semibold text-white mb-2">Millenium Hawk V2</h3>
-              <p class="text-brand-text text-sm mb-4 flex-grow">Versatile drone for agricultural surveys and precision farming.</p>
+              <h3 class="text-2xl font-semibold text-white mb-2" data-translate-key="productHawkName">SOLA Hawk V2</h3>
+              <p class="text-brand-text text-sm mb-4 flex-grow" data-translate-key="productHawkDescription">Versatile drone for agricultural surveys and precision farming.</p>
               <div class="mb-4">
-                <h4 class="text-sm font-semibold text-brand-accent mb-2">Key Specs:</h4>
+                <h4 class="text-sm font-semibold text-brand-accent mb-2" data-translate-key="productKeySpecs">Key Specs:</h4>
                 <ul class="space-y-1 text-xs text-brand-text">
-                  <li class="flex items-center"><svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke-width="1.5" stroke="currentColor" class="w-4 h-4 mr-2 text-brand-accent flex-shrink-0"><path stroke-linecap="round" stroke-linejoin="round" d="M6.827 6.175A2.31 2.31 0 015.186 7.23c-.38.054-.757.112-1.134.175C2.999 7.58 2.25 8.507 2.25 9.574V18a2.25 2.25 0 002.25 2.25h15A2.25 2.25 0 0021.75 18V9.574c0-1.067-.75-1.994-1.802-2.169a47.865 47.865 0 00-1.134-.175 2.31 2.31 0 01-1.64-1.055l-.822-1.316a2.192 2.192 0 00-1.736-1.039 48.774 48.774 0 00-5.232 0 2.192 2.192 0 00-1.736 1.039l-.821 1.316z" /><path stroke-linecap="round" stroke-linejoin="round" d="M16.5 12.75a4.5 4.5 0 11-9 0 4.5 4.5 0 019 0zM18.75 10.5h.008v.008h-.008V10.5z" /></svg><span>Multispectral Sensor</span></li>
-                  <li class="flex items-center"><svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke-width="1.5" stroke="currentColor" class="w-4 h-4 mr-2 text-brand-accent flex-shrink-0"><path stroke-linecap="round" stroke-linejoin="round" d="M21 10.5V6.75a2.25 2.25 0 00-2.25-2.25H5.25A2.25 2.25 0 003 6.75v10.5A2.25 2.25 0 005.25 19.5h13.5A2.25 2.25 0 0021 17.25V13.5M19.5 10.5v3m0 0H4.5m15 0v-3m0 0H4.5" /><path stroke-linecap="round" stroke-linejoin="round" d="M15.75 6.75h.008v.008h-.008V6.75z" /></svg><span>Automated Flight Paths</span></li>
-                  <li class="flex items-center"><svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke-width="1.5" stroke="currentColor" class="w-4 h-4 mr-2 text-brand-accent flex-shrink-0"><path stroke-linecap="round" stroke-linejoin="round" d="M8.25 4.5l7.5 7.5-7.5 7.5" /><path stroke-linecap="round" stroke-linejoin="round" d="M3.75 4.5l7.5 7.5-7.5 7.5" /></svg><span>45 Min Flight Time</span></li>
-                  <li class="flex items-center"><span>Durable Frame</span></li>
+                  <li class="flex items-center"><svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke-width="1.5" stroke="currentColor" class="w-4 h-4 mr-2 text-brand-accent flex-shrink-0"><path stroke-linecap="round" stroke-linejoin="round" d="M6.827 6.175A2.31 2.31 0 015.186 7.23c-.38.054-.757.112-1.134.175C2.999 7.58 2.25 8.507 2.25 9.574V18a2.25 2.25 0 002.25 2.25h15A2.25 2.25 0 0021.75 18V9.574c0-1.067-.75-1.994-1.802-2.169a47.865 47.865 0 00-1.134-.175 2.31 2.31 0 01-1.64-1.055l-.822-1.316a2.192 2.192 0 00-1.736-1.039 48.774 48.774 0 00-5.232 0 2.192 2.192 0 00-1.736 1.039l-.821 1.316z" /><path stroke-linecap="round" stroke-linejoin="round" d="M16.5 12.75a4.5 4.5 0 11-9 0 4.5 4.5 0 019 0zM18.75 10.5h.008v.008h-.008V10.5z" /></svg><span data-translate-key="productHawkSpecSensor">Multispectral Sensor</span></li>
+                  <li class="flex items-center"><svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke-width="1.5" stroke="currentColor" class="w-4 h-4 mr-2 text-brand-accent flex-shrink-0"><path stroke-linecap="round" stroke-linejoin="round" d="M21 10.5V6.75a2.25 2.25 0 00-2.25-2.25H5.25A2.25 2.25 0 003 6.75v10.5A2.25 2.25 0 005.25 19.5h13.5A2.25 2.25 0 0021 17.25V13.5M19.5 10.5v3m0 0H4.5m15 0v-3m0 0H4.5" /><path stroke-linecap="round" stroke-linejoin="round" d="M15.75 6.75h.008v.008h-.008V6.75z" /></svg><span data-translate-key="productHawkSpecFlightPaths">Automated Flight Paths</span></li>
+                  <li class="flex items-center"><svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke-width="1.5" stroke="currentColor" class="w-4 h-4 mr-2 text-brand-accent flex-shrink-0"><path stroke-linecap="round" stroke-linejoin="round" d="M8.25 4.5l7.5 7.5-7.5 7.5" /><path stroke-linecap="round" stroke-linejoin="round" d="M3.75 4.5l7.5 7.5-7.5 7.5" /></svg><span data-translate-key="productHawkSpecFlightTime">45 Min Flight Time</span></li>
+                  <li class="flex items-center"><span data-translate-key="productHawkSpecFrame">Durable Frame</span></li>
                 </ul>
               </div>
-              <p class="text-2xl font-bold text-brand-accent mb-4">$4,500</p>
+              <p class="text-2xl font-bold text-brand-accent mb-4" data-translate-key="productHawkPrice">$4,500</p>
               <div class="mt-auto">
-                <button class="w-full bg-brand-accent text-brand-primary font-semibold py-2 px-4 rounded-md hover:bg-opacity-80 transition-colors duration-150" onclick="showProductDetails('Millenium Hawk V2')">View Details</button>
+                <button class="w-full bg-brand-accent text-brand-primary font-semibold py-2 px-4 rounded-md hover:bg-opacity-80 transition-colors duration-150" onclick="showProductDetails('SOLA Hawk V2')">View Details</button>
               </div>
             </div>
           </div>
         </div>
 
         <div class="mt-20 bg-brand-secondary p-8 rounded-lg shadow-xl">
-          <h2 class="text-2xl font-bold text-brand-accent mb-4 text-center">Can't find what you're looking for?</h2>
-          <p class="text-brand-text text-center mb-6">
+          <h2 class="text-2xl font-bold text-brand-accent mb-4 text-center" data-translate-key="customSolutionTitle">Can't find what you're looking for?</h2>
+          <p class="text-brand-text text-center mb-6" data-translate-key="customSolutionDescription">
             We offer custom drone solutions tailored to your specific requirements. Get in touch with our specialists to discuss your project.
           </p>
           <div class="text-center">
              <a 
                 href="./contact.html" 
                 class="inline-block bg-brand-accent text-brand-primary font-semibold py-3 px-8 rounded-md hover:bg-opacity-80 transition-colors duration-150 text-lg"
+                data-translate-key="customSolutionButton"
               >
                 Request Custom Solution
               </a>
@@ -218,7 +219,7 @@
 
   <footer class="bg-brand-secondary text-brand-text py-8">
     <div class="max-w-7xl mx-auto px-4 sm:px-6 lg:px-8 text-center">
-      <p><span data-translate-key="footerRights">&copy; <span id="current-year"></span> Millenium Drones. All rights reserved.</span></p>
+      <p><span data-translate-key="footerRights">&copy; <span id="current-year"></span> SOLA. All rights reserved.</span></p>
       <p class="text-sm mt-1" data-translate-key="footerSlogan">Pioneering the Future of Aerial Technology.</p>
     </div>
   </footer>

--- a/script.js
+++ b/script.js
@@ -7,13 +7,116 @@ const translations = {
     navDrones: "Our Drones",
     navContact: "Contact Us",
     // Hero Section (index.html)
-    heroTitle1: "Millenium Drones",
+    heroTitle1: "SOLA",
     heroTitle2: "Elevate Your Perspective",
     heroDescription: "Discover the next generation of autonomous aerial solutions. Precision engineering, cutting-edge technology, and unparalleled performance for every mission.",
     heroBtnExplore: "Explore Drones",
     heroBtnLearnMore: "Learn More",
+    // About Teaser (index.html)
+    aboutTeaserTitle: "Who We Are",
+    aboutTeaserSlogan: "Innovating the Skies with SOLA",
+    aboutTeaserDescription: "We are dedicated to designing and manufacturing state-of-the-art drones that push the boundaries of aerial technology. Our commitment is to quality, reliability, and innovation.",
+    aboutTeaserLink: "Learn more about us →",
+    // Products Highlight (index.html)
+    productsHighlightTitle: "Our Flagship Drones",
+    productsHighlightSlogan: "Engineered for performance, built for reliability.",
+    productKeySpecs: "Key Specs:",
+    productViewDetailsBtn: "View Details",
+    // Falcon X1
+    productFalconName: "SOLA Falcon X1",
+    productFalconDescription: "High-performance surveillance and reconnaissance drone with extended flight time and advanced optics.",
+    productFalconSpecCamera: "4K HDR Camera",
+    productFalconSpecFlight: "55 Min Flight Time",
+    productFalconSpecRange: "10km Range",
+    productFalconPrice: "$2,499",
+    // Sparrow Z3
+    productSparrowName: "SOLA Sparrow Z3",
+    productSparrowDescription: "Compact and agile drone perfect for aerial photography and videography enthusiasts.",
+    productSparrowSpecCamera: "2.7K Camera",
+    productSparrowSpecFlight: "30 Min Flight Time",
+    productSparrowSpecRange: "5km Range",
+    productSparrowPrice: "$899",
+    // Eagle Pro
+    productEagleName: "SOLA Eagle Pro",
+    productEagleDescription: "Professional-grade drone for industrial inspections and mapping solutions.",
+    productEagleSpecImaging: "Thermal Imaging",
+    productEagleSpecPrecision: "RTK Precision",
+    productEagleSpecFlight: "70 Min Flight Time",
+    productEaglePrice: "$7,999",
+    viewAllDronesBtn: "View All Drones",
+    // Features Highlight (index.html)
+    featuresTitle: "Why Choose SOLA?",
+    featuresSlogan: "Experience the difference with our advanced drone technology.",
+    featureExtendedRangeTitle: "Extended Range",
+    featureExtendedRangeDesc: "Our drones boast impressive operational ranges, allowing you to cover more ground.",
+    featureBatteryLifeTitle: "Superior Battery Life",
+    featureBatteryLifeDesc: "Fly longer and capture more with our high-capacity, intelligent battery systems.",
+    featureOpticsTitle: "Advanced Optics",
+    featureOpticsDesc: "Capture stunning visuals with high-resolution cameras and state-of-the-art sensors.",
+    // Call To Action (index.html)
+    ctaTitle: "Ready to Elevate Your Operations?",
+    ctaSlogan: "Explore our drone solutions today.",
+    ctaViewOurDrones: "View Our Drones",
+    ctaContactSalesBtn: "Contact Sales",
+    // About Page (about.html)
+    aboutPageTitle: "About SOLA",
+    aboutPageSlogan: "Pioneering the future of aerial solutions with passion and precision.",
+    ourStoryTitle: "Our Story",
+    ourStoryParagraph1: "Founded in 2020 by a team of passionate engineers and aviation experts, SOLA was born from a shared vision: to make advanced aerial technology accessible and impactful. We saw the potential for drones to transform various sectors, from agriculture and construction to public safety and cinematography. Starting in a small workshop, we meticulously designed and tested our first prototypes, focusing on durability, performance, and user-friendliness. Today, SOLA has grown into a trusted name, known for pushing the boundaries of what's possible with unmanned aerial systems. Our commitment to research and development ensures that we stay at the forefront of the industry, delivering cutting-edge solutions to our clients worldwide.",
+    ourMissionTitle: "Our Mission",
+    ourMissionParagraph: "Our mission is to revolutionize industries through innovative aerial technology, providing reliable, efficient, and intelligent drone solutions that empower our customers to achieve more.",
+    ourVisionTitle: "Our Vision",
+    ourVisionParagraph: "To be the global leader in drone technology, recognized for our commitment to quality, innovation, and customer success.",
+    coreValuesTitle: "Our Core Values",
+    valueInnovationTitle: "Innovation",
+    valueInnovationDesc: "Constantly pushing the boundaries of technology to deliver cutting-edge solutions.",
+    valueReliabilityTitle: "Reliability",
+    valueReliabilityDesc: "Building robust and dependable drones that perform consistently in demanding environments.",
+    valueCustomerFocusTitle: "Customer Focus",
+    valueCustomerFocusDesc: "Understanding and exceeding our customers' needs with tailored solutions and support.",
+    teamImageCaption: "The dedicated team behind SOLA.",
+    // Products Page (products.html)
+    productsPageTitle: "Our Drone Fleet",
+    productsPageSlogan: "Explore our comprehensive range of advanced aerial solutions, designed for diverse applications and industries.",
+    productFalconSpecAI: "AI Object Tracking",
+    productSparrowSpecDesign: "Lightweight Design",
+    productEagleSpecWeather: "Weather Resistant",
+    productHawkName: "SOLA Hawk V2",
+    productHawkDescription: "Versatile drone for agricultural surveys and precision farming.",
+    productHawkSpecSensor: "Multispectral Sensor",
+    productHawkSpecFlightPaths: "Automated Flight Paths",
+    productHawkSpecFlightTime: "45 Min Flight Time",
+    productHawkSpecFrame: "Durable Frame",
+    productHawkPrice: "$4,500",
+    customSolutionTitle: "Can't find what you're looking for?",
+    customSolutionDescription: "We offer custom drone solutions tailored to your specific requirements. Get in touch with our specialists to discuss your project.",
+    customSolutionButton: "Request Custom Solution",
+    // Contact Page (contact.html)
+    contactPageTitle: "Get In Touch",
+    contactPageSlogan: "We're here to help with any questions you have about our drones or services. Reach out and let's talk.",
+    sendMessageTitle: "Send Us a Message",
+    formLabelName: "Full Name",
+    formLabelEmail: "Email Address",
+    formLabelSubject: "Subject",
+    formLabelMessage: "Message",
+    formButtonSend: "Send Message",
+    formFeedbackSuccessTitle: "Thank You!",
+    formFeedbackSuccessMsg: "Your message has been sent successfully. We'll get back to you soon.",
+    contactInfoTitle: "Contact Information",
+    contactEmailTitle: "Email Us",
+    contactEmailValue: "info@sola-drones.com",
+    contactPhoneTitle: "Call Us",
+    contactPhoneValue: "+1 (555) 123-4567",
+    contactAddressTitle: "Visit Us",
+    contactAddressValue: "123 Drone Lane, Innovation City, CA 90210",
+    mapTitle: "Company Location",
+    // Page Titles
+    titleHome: "SOLA - Home",
+    titleAbout: "About Us - SOLA",
+    titleProducts: "Our Drones - SOLA",
+    titleContact: "Contact Us - SOLA",
     // Common
-    footerRights: "Millenium Drones. All rights reserved.",
+    footerRights: "SOLA. All rights reserved.",
     footerSlogan: "Pioneering the Future of Aerial Technology."
   },
   ru: {
@@ -23,13 +126,116 @@ const translations = {
     navDrones: "Наши дроны",
     navContact: "Контакты",
     // Hero Section (index.html)
-    heroTitle1: "Миллениум Дроны", // Might need a better brand translation or keep as is
+    heroTitle1: "SOLA",
     heroTitle2: "Поднимите свой взгляд",
     heroDescription: "Откройте для себя следующее поколение автономных воздушных решений. Точное проектирование, передовые технологии и непревзойденная производительность для каждой миссии.",
     heroBtnExplore: "Исследовать дроны",
     heroBtnLearnMore: "Узнать больше",
+    // About Teaser (index.html)
+    aboutTeaserTitle: "Кто мы",
+    aboutTeaserSlogan: "Инновации в небе с SOLA",
+    aboutTeaserDescription: "Мы посвятили себя разработке и производству самых современных дронов, которые расширяют границы воздушных технологий. Наша приверженность – качество, надежность и инновации.",
+    aboutTeaserLink: "Узнать о нас больше →",
+    // Products Highlight (index.html)
+    productsHighlightTitle: "Наши флагманские дроны",
+    productsHighlightSlogan: "Разработано для производительности, создано для надежности.",
+    productKeySpecs: "Ключевые характеристики:",
+    productViewDetailsBtn: "Посмотреть детали",
+    // Falcon X1
+    productFalconName: "SOLA Falcon X1",
+    productFalconDescription: "Высокопроизводительный дрон для наблюдения и разведки с увеличенным временем полета и передовой оптикой.",
+    productFalconSpecCamera: "4K HDR камера",
+    productFalconSpecFlight: "55 мин время полета",
+    productFalconSpecRange: "10 км дальность",
+    productFalconPrice: "$2,499",
+    // Sparrow Z3
+    productSparrowName: "SOLA Sparrow Z3",
+    productSparrowDescription: "Компактный и маневренный дрон, идеально подходящий для любителей аэрофотосъемки и видеографии.",
+    productSparrowSpecCamera: "2.7K камера",
+    productSparrowSpecFlight: "30 мин время полета",
+    productSparrowSpecRange: "5 км дальность",
+    productSparrowPrice: "$899",
+    // Eagle Pro
+    productEagleName: "SOLA Eagle Pro",
+    productEagleDescription: "Профессиональный дрон для промышленных инспекций и картографических решений.",
+    productEagleSpecImaging: "Тепловизионная съемка",
+    productEagleSpecPrecision: "RTK точность",
+    productEagleSpecFlight: "70 мин время полета",
+    productEaglePrice: "$7,999",
+    viewAllDronesBtn: "Посмотреть все дроны",
+    // Features Highlight (index.html)
+    featuresTitle: "Почему выбирают SOLA?",
+    featuresSlogan: "Ощутите разницу с нашими передовыми технологиями дронов.",
+    featureExtendedRangeTitle: "Увеличенная дальность",
+    featureExtendedRangeDesc: "Наши дроны обладают впечатляющими рабочими диапазонами, позволяя вам охватывать больше территории.",
+    featureBatteryLifeTitle: "Превосходное время работы от батареи",
+    featureBatteryLifeDesc: "Летайте дольше и снимайте больше с нашими высокоемкими интеллектуальными аккумуляторными системами.",
+    featureOpticsTitle: "Передовая оптика",
+    featureOpticsDesc: "Снимайте потрясающие визуальные эффекты с помощью камер высокого разрешения и самых современных датчиков.",
+    // Call To Action (index.html)
+    ctaTitle: "Готовы улучшить свои операции?",
+    ctaSlogan: "Ознакомьтесь с нашими решениями для дронов уже сегодня.",
+    ctaViewOurDrones: "Посмотреть наши дроны",
+    ctaContactSalesBtn: "Связаться с отделом продаж",
+    // About Page (about.html)
+    aboutPageTitle: "О SOLA",
+    aboutPageSlogan: "Прокладывая путь в будущее воздушных решений со страстью и точностью.",
+    ourStoryTitle: "Наша история",
+    ourStoryParagraph1: "Основанная в 2020 году командой увлеченных инженеров и экспертов в области авиации, SOLA родилась из общего видения: сделать передовые воздушные технологии доступными и эффективными. Мы увидели потенциал дронов для трансформации различных отраслей, от сельского хозяйства и строительства до общественной безопасности и кинематографии. Начиная в небольшой мастерской, мы тщательно разрабатывали и тестировали наши первые прототипы, уделяя особое внимание прочности, производительности и удобству использования. Сегодня SOLA превратилась в доверенное имя, известное тем, что расширяет границы возможного с беспилотными авиационными системами. Наша приверженность исследованиям и разработкам гарантирует, что мы остаемся на переднем крае отрасли, предоставляя передовые решения нашим клиентам по всему миру.",
+    ourMissionTitle: "Наша миссия",
+    ourMissionParagraph: "Наша миссия — революционизировать отрасли с помощью инновационных воздушных технологий, предоставляя надежные, эффективные и интеллектуальные решения для дронов, которые позволяют нашим клиентам достигать большего.",
+    ourVisionTitle: "Наше видение",
+    ourVisionParagraph: "Быть мировым лидером в области технологий дронов, признанным за нашу приверженность качеству, инновациям и успеху клиентов.",
+    coreValuesTitle: "Наши основные ценности",
+    valueInnovationTitle: "Инновации",
+    valueInnovationDesc: "Постоянно расширяем границы технологий для предоставления передовых решений.",
+    valueReliabilityTitle: "Надежность",
+    valueReliabilityDesc: "Создание прочных и надежных дронов, которые стабильно работают в сложных условиях.",
+    valueCustomerFocusTitle: "Ориентация на клиента",
+    valueCustomerFocusDesc: "Понимание и превосходство потребностей наших клиентов с помощью индивидуальных решений и поддержки.",
+    teamImageCaption: "Преданная команда SOLA.",
+    // Products Page (products.html)
+    productsPageTitle: "Наш парк дронов",
+    productsPageSlogan: "Ознакомьтесь с нашим широким ассортиментом передовых воздушных решений, предназначенных для различных применений и отраслей.",
+    productFalconSpecAI: "ИИ отслеживание объектов",
+    productSparrowSpecDesign: "Легкая конструкция",
+    productEagleSpecWeather: "Устойчивость к погодным условиям",
+    productHawkName: "SOLA Hawk V2",
+    productHawkDescription: "Универсальный дрон для сельскохозяйственных обследований и точного земледелия.",
+    productHawkSpecSensor: "Мультиспектральный датчик",
+    productHawkSpecFlightPaths: "Автоматизированные маршруты полетов",
+    productHawkSpecFlightTime: "45 мин время полета",
+    productHawkSpecFrame: "Прочная рама",
+    productHawkPrice: "$4,500",
+    customSolutionTitle: "Не можете найти то, что ищете?",
+    customSolutionDescription: "Мы предлагаем индивидуальные решения для дронов, адаптированные к вашим конкретным требованиям. Свяжитесь с нашими специалистами, чтобы обсудить ваш проект.",
+    customSolutionButton: "Запросить индивидуальное решение",
+    // Contact Page (contact.html)
+    contactPageTitle: "Свяжитесь с нами",
+    contactPageSlogan: "Мы здесь, чтобы помочь с любыми вопросами о наших дронах или услугах. Обращайтесь, и давайте поговорим.",
+    sendMessageTitle: "Отправьте нам сообщение",
+    formLabelName: "Полное имя",
+    formLabelEmail: "Адрес электронной почты",
+    formLabelSubject: "Тема",
+    formLabelMessage: "Сообщение",
+    formButtonSend: "Отправить сообщение",
+    formFeedbackSuccessTitle: "Спасибо!",
+    formFeedbackSuccessMsg: "Ваше сообщение успешно отправлено. Мы свяжемся с вами в ближайшее время.",
+    contactInfoTitle: "Контактная информация",
+    contactEmailTitle: "Напишите нам",
+    contactEmailValue: "info@sola-drones.com",
+    contactPhoneTitle: "Позвоните нам",
+    contactPhoneValue: "+1 (555) 123-4567",
+    contactAddressTitle: "Посетите нас",
+    contactAddressValue: "123 Дрон Лейн, Инновационный Город, CA 90210",
+    mapTitle: "Местоположение компании",
+    // Page Titles
+    titleHome: "SOLA - Главная",
+    titleAbout: "О нас - SOLA",
+    titleProducts: "Наши дроны - SOLA",
+    titleContact: "Контакты - SOLA",
     // Common
-    footerRights: "Миллениум Дроны. Все права защищены.",
+    footerRights: "SOLA. Все права защищены.",
     footerSlogan: "Создавая будущее авиационных технологий."
   }
 };
@@ -60,6 +266,25 @@ function setLanguage(lang) {
 
     // Update active nav link text if necessary (they are also covered by data-translate-key)
     highlightActiveLink();
+
+    // Update page title
+    const pageFileName = window.location.pathname.split('/').pop().replace('.html', ''); // e.g., "index", "about"
+    let titleKey = '';
+    if (pageFileName === 'index' || pageFileName === '') {
+      titleKey = 'titleHome';
+    } else if (pageFileName === 'about') {
+      titleKey = 'titleAbout';
+    } else if (pageFileName === 'products') {
+      titleKey = 'titleProducts';
+    } else if (pageFileName === 'contact') {
+      titleKey = 'titleContact';
+    }
+
+    if (titleKey && translations[lang][titleKey]) {
+      document.title = translations[lang][titleKey];
+    } else if (titleKey) {
+      console.warn(`No title translation found for key: ${titleKey} in language: ${lang}`);
+    }
 
   } else {
     console.error(`Language ${lang} not supported.`);
@@ -205,10 +430,15 @@ document.addEventListener('DOMContentLoaded', () => {
       
       contactForm.style.display = 'none';
       formFeedback.classList.remove('hidden');
+
+      const successTitleKey = "formFeedbackSuccessTitle";
+      const successMessageKey = "formFeedbackSuccessMsg";
+      const currentTranslations = translations[currentLanguage] || translations.en;
+
       formFeedback.innerHTML = `
         <div class="text-center py-8">
-          <h3 class="text-xl font-semibold text-green-400">Thank You!</h3>
-          <p class="text-brand-text mt-2">Your message has been sent successfully. We'll get back to you soon.</p>
+          <h3 class="text-xl font-semibold text-green-400">${currentTranslations[successTitleKey]}</h3>
+          <p class="text-brand-text mt-2">${currentTranslations[successMessageKey]}</p>
         </div>
       `;
       (contactForm as HTMLFormElement).reset();


### PR DESCRIPTION
- Rebranded 'Millenium Drones' to 'SOLA' across all site content, including page titles, text, alt attributes, and product names.
- Updated brand name in English and Russian translation files (script.js).

- Expanded internationalization (i18n) to cover all major text content on index.html, about.html, products.html, and contact.html.
- Added new translation keys and machine-translated Russian text to script.js for all pages.
- Applied 'data-translate-key' attributes to respective HTML elements.
- Updated page titles to be translatable based on selected language.
- Modified contact form success message to display in the selected language.